### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that exposes tools to build and clean Delphi projects (.dproj/.groupproj) on Windows using MSBuild, initializing the RAD Studio environment via rsvars.bat.
 
+<a href="https://glama.ai/mcp/servers/@flydev-fr/mcp-delphi">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@flydev-fr/mcp-delphi/badge" alt="Delphi Build Server MCP server" />
+</a>
+
 ## Prerequisites
 - Windows
 - Node.js >= 18
@@ -131,4 +135,3 @@ This repo includes small Delphi test projects in `test/projects`, and a Lazarus 
   - `npm publish` (or `pnpm publish`)
 
 If publishing under a scope, set the package name accordingly and ensure you are logged in with proper access.
-


### PR DESCRIPTION
This PR adds a badge for the [Delphi Build Server](https://glama.ai/mcp/servers/@flydev-fr/mcp-delphi) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@flydev-fr/mcp-delphi">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@flydev-fr/mcp-delphi/badge" alt="Delphi Build Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.